### PR TITLE
Update Player.php

### DIFF
--- a/src/Syntax/SteamApi/Steam/Player.php
+++ b/src/Syntax/SteamApi/Steam/Player.php
@@ -34,6 +34,10 @@ class Player extends Client
     public function GetPlayerLevelDetails()
     {
         $details = $this->GetBadges();
+        
+        if(count((array)$details) == 0){
+            return NULL;
+        }
 
         $details = new Level($details);
 


### PR DESCRIPTION
When a player's account is private and you call GetPlayerLevelDetails() the Containers\Player\Level class cannot be created because $details = $this->GetBadges(); will return empty and the Containers\Player\Level class constructor will fail.

Should it return NULL? You can just check if GetPlayerLevelDetails () returns NULL then there account is probably private.